### PR TITLE
fix: anchorRef now allows any element type

### DIFF
--- a/core.d.ts
+++ b/core.d.ts
@@ -45,9 +45,9 @@ export function createPopupState(options: {
  * @param {object} popupState the argument passed to the child function of
  * `PopupState`
  */
-export function anchorRef(
+export function anchorRef<T = HTMLElement>(
   popupState: PopupState
-): (popupState: HTMLElement | undefined) => any
+): (popupState: T | undefined) => void
 
 /**
  * Creates props for a component that opens the popup when clicked.


### PR DESCRIPTION
There's a bug in the type of `anchorRef` which prevents getting ref of a specific element type. This is necessary when you have a component that is strongly typed to accept a ref only of a certain element type.