### PR TITLE
Move deprecated @mui/styles to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@jedwards1211/eslint-config": "^2.0.2",
     "@jedwards1211/eslint-config-flow": "^3.0.0",
     "@jedwards1211/eslint-config-react": "^4.0.0",
+    "@mui/styles": "^5.0.0",
     "@types/classnames": "^2.2.9",
     "@types/prop-types": "^15.7.3",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",
@@ -150,7 +151,6 @@
     "@babel/runtime": "^7.12.5",
     "@mui/icons-material": "^5.0.0",
     "@mui/material": "^5.0.0",
-    "@mui/styles": "^5.0.0",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2"
   },


### PR DESCRIPTION
It is only used in demos and not in production code
We want to make it easy to move away from JSS as described in https://mui.com/material-ui/guides/migration-v4/#migrate-from-jss