### PR TITLE
fix: do not set anchor when using custom anchor

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -163,12 +163,12 @@ export function usePopupState({
         _openEventType: event?.type,
       }
 
-      if (event?.currentTarget) {
-        if (!state.setAnchorElUsed) {
-          newState.anchorEl = event?.currentTarget as any
+      if (!state.setAnchorElUsed) {
+        if (event?.currentTarget) {
+            newState.anchorEl = event?.currentTarget as any
+        } else if (element) {
+          newState.anchorEl = element
         }
-      } else if (element) {
-        newState.anchorEl = element
       }
 
       return newState


### PR DESCRIPTION
I'm trying to use `HoverMenu` with a custom anchor (set via `anchorRef(popupState)`). This doesn't work as the `anchorEl` gets reset internally at some point. 
I do think that the `anchorEl` should never be set if using a custom anchor. 

As a side-note: I cannot test things properly as I can't install dev-dependencies (some seem to be private)